### PR TITLE
[BUG Fix] Fixes paths which may contains spaces

### DIFF
--- a/server/src/format.ts
+++ b/server/src/format.ts
@@ -15,12 +15,13 @@ let prettierCmd = ''
 
 export function initFormatter(workspaceFolders: WorkspaceFolder[]) {
   for (const wsf of workspaceFolders) {
-    const prettierPath = resolve(
-      fileURLToPath(wsf.uri),
-      'node_modules',
-      '.bin',
-      'prettier',
-    )
+    const prettierPath = `"${
+      resolve(
+        fileURLToPath(wsf.uri),
+        'node_modules',
+        '.bin',
+        'prettier',
+      )}"`;
 
     if (isAwkPluginAvailable(prettierPath)) {
       prettierCmd = prettierPath


### PR DESCRIPTION
## What

Paths which contain spaces break the `exec` command since the paths are not escaped and they are treated as separate strings.
